### PR TITLE
Release 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiwicom/orbit-design-tokens",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Design tokens for Kiwi.com.",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## Changelog
Added tokens `backgroundBadgeWhite` and `colorTextBadgeWhite` for the white type of Badge

Changed value of token `boxShadowElevatedLevel1` to `0 4px 12px 0 rgba(23, 27, 30, 0.3)`

Fixed deep-merge for `getTokens` function. Palette colors were not merged with passed custom foundations.

Fixed deprecated README.