### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiwicom/orbit-design-tokens",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Design tokens for Kiwi.com.",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## Changelog

feat: typescript types (#247)
chore: bump flow-bin from 0.120.1 to 0.121.0 (#202)
chore: bump jest from 25.1.0 to 25.3.0 (#227)
chore: bump eslint-plugin-import from 2.20.1 to 2.20.2 (#219)
chore: bump @babel/parser from 7.8.8 to 7.9.4 (#213)
chore: bump eslint-config-prettier from 6.10.0 to 6.10.1 (#210)
chore: bump @babel/preset-flow from 7.8.3 to 7.9.0 (#204)
chore: bump @babel/core from 7.8.7 to 7.9.0 (#206)
chore: bump eslint-plugin-flowtype from 4.6.0 to 4.7.0 (#214)
chore: bump flow-bin from 0.121.0 to 0.122.0 (#222)
chore: bump @babel/preset-env from 7.8.7 to 7.9.5 (#226)