### PR TITLE
ci: run build script as a sanity check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
       - run:
           name: Run all tests
           command: yarn test-ci
+      - run:
+          name: Run build (sanity check)
+          command: yarn build
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build-android": "theo ./src/theo/theo-spec.json --transform android --format android.xml --dest ./output",
     "build:lib": "babel --out-dir lib --ignore **/*.test.js,src/theo/* src && yarn copy:lib",
     "build:es": "babel --config-file ./.babel-es --no-babelrc --out-dir es --ignore **/*.test.js,src/theo/* src && yarn copy:es",
-    "build": "yarn run generate-json && yarn run build:lib && yarn run build-html && yarn run build-web && yarn run build-ios && yarn run build-android",
+    "build": "yarn run build:lib && yarn run generate-json && yarn run build-html && yarn run build-web && yarn run build-ios && yarn run build-android",
     "copy:lib": "copyfiles -u 1 'src/**/*.js.flow' lib && copyfiles -u 1 'src/**/*.d.ts' lib",
     "copy:es": "copyfiles -u 1 'src/**/*.js.flow' es && copyfiles -u 1 'src/**/*.d.ts' es ",
     "test": "jest",


### PR DESCRIPTION
While working on #292 I accidentally implemented a failing build script. I think the CI should run the build script as a sanity check to catch mistakes like that.

Also, while implementing this I noticed the (possibly) incorrect order of commands in the `build` script. `generate-theo-parser.js` requires a module from the `lib` directory, which doesn't exist yet, so I swapped `generate-json` and `build:lib`.